### PR TITLE
Remove HTTP proxy configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Mon Jan 15 20:53:38 PST 2018
-systemProp.http.proxyHost=127.0.0.1
-systemProp.https.proxyPort=52804
-org.gradle.jvmargs=-Xmx1536m
-systemProp.https.proxyHost=127.0.0.1
-systemProp.http.proxyPort=52804
+


### PR DESCRIPTION
Removed the specified HTTP proxy config in **gradle.propeties** file to prevent `Gradle sync failed: Connection refused: connect` error when building project in android studio